### PR TITLE
Fixed inconcistency in lesson 3 - return a float

### DIFF
--- a/unit-4-data-types/lesson-3-return-a-float/README.md
+++ b/unit-4-data-types/lesson-3-return-a-float/README.md
@@ -3,6 +3,6 @@
 Take your previous percentage function, but this time return the percentage as a float type. Round to 1 decimal place.
 
 ```python
-return_percentage(60) == 100.0
-return_percentage(30) == 50.0
+return_percentage_as_float(60) == 100.0
+return_percentage_as_float(30) == 50.0
 ```

--- a/unit-4-data-types/lesson-3-return-a-float/main.py
+++ b/unit-4-data-types/lesson-3-return-a-float/main.py
@@ -1,2 +1,2 @@
-def return_float(minutes):
+def return_percentage_as_float(minutes):
     pass

--- a/unit-4-data-types/lesson-3-return-a-float/tests.py
+++ b/unit-4-data-types/lesson-3-return-a-float/tests.py
@@ -3,7 +3,7 @@ import unittest
 
 class ReturnAFloatTest(unittest.TestCase):
     def test_return_a_float(self):
-        self.assertEqual(return_float(30), 50.0)
-        self.assertEqual(return_float(12), 20.0)
-        self.assertEqual(return_float(42), 70.0)
-        self.assertEqual(return_float(60), 100.0)
+        self.assertEqual(return_percentage_as_float(30), 50.0)
+        self.assertEqual(return_percentage_as_float(12), 20.0)
+        self.assertEqual(return_percentage_as_float(42), 70.0)
+        self.assertEqual(return_percentage_as_float(60), 100.0)


### PR DESCRIPTION
Example code called the function `return_percentage`, while our code and tests called the function `return_float`. Have renamed both to `return_percentage_as_float` for consistency and making it clear what is expected.